### PR TITLE
Add support for deploying to multiple hosts

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -30,9 +30,6 @@ export HTDOCS="$HOME/htdocs"
 export GITHUB_BRANCH=${GITHUB_REF##*heads/}
 export CI_SCRIPT_OPTIONS="ci_script_options"
 
-# get hostname
-hostname=$(cat "$hosts_file" | shyaml get-value "$GITHUB_BRANCH.hostname")
-
 printf "[\e[0;34mNOTICE\e[0m] Setting up SSH access to server.\n"
 
 SSH_DIR="$HOME/.ssh"
@@ -60,8 +57,7 @@ if [[ -n "$VAULT_ADDR" ]]; then
 
     # Create ssh config file. `~/.ssh/config` does not work.
     cat > /etc/ssh/ssh_config <<EOL
-Host $hostname
-HostName $hostname
+Host *
 IdentityFile ${SSH_DIR}/signed-cert.pub
 IdentityFile ${SSH_DIR}/id_rsa
 User root


### PR DESCRIPTION
With current SSH config, it's not possible to deploy to multiple hosts as the config is applied to only one host. This PR fixes it so that the config applied to all the hosts.

I've tested this change. It works with both - single and multiple hosts.