### PR TITLE
Remove composer.json from exclude list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Deploy WordPress code to a server'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'docker://rtcamp/action-deploy-wordpress:v2.1.0'
+  image: 'docker://rtcamp/action-deploy-wordpress:v2.1.1'
 branding:
   icon: 'upload-cloud'
   color: 'yellow'

--- a/deploy.php
+++ b/deploy.php
@@ -38,7 +38,6 @@ set('rsync', [
 		'.git',
 		'.github',
 		'deploy.php',
-		'composer.json',
 		'composer.lock',
 		'.env',
 		'.env.example',


### PR DESCRIPTION
Remove composer.json from exclude list, as it may be needed in case of few plugins like: https://wordpress.org/plugins/enable-media-replace/