### PR TITLE
Automatic minor version upgrade via WP_MINOR_UPDATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ This GitHub action's behavior can be customized using following environment vari
 
 Variable          | Default | Possible  Values            | Purpose
 ------------------|---------|-----------------------------|----------------------------------------------------
-`MU_PLUGINS_URL`  | null    | vip, any git repo url         | If value is `vip`, then action will clone [VIP's MU plugins](https://github.com/Automattic/vip-mu-plugins-public) as `mu-plugins` folder. If you want to specifiy a non-VIP mu-plugins repo, you can provide a publicly accessible mu-plugins repo URL as the value.
+`MU_PLUGINS_URL`  | null    | vip, any git repo url       | If value is `vip`, then action will clone [VIP's MU plugins](https://github.com/Automattic/vip-mu-plugins-public) as `mu-plugins` folder. If you want to specifiy a non-VIP mu-plugins repo, you can provide a publicly accessible mu-plugins repo URL as the value.
 `WP_VERSION`      | latest  | Any valid WordPress version | If you specify a WordPress version, then that speicifc WordPress version will be downloaded, instead of latest WordPress version.
+`WP_MINOR_UPDATE` | null    | `true` / `false`            | If set to `true`, latest minor version of `WP_VERSION` will be taken.
 `JUMPHOST_SERVER` | null    | Hostname/IP address of the jumphost server | If the deployment server is not directly accessible, and needs a jumphost, then this method should be used. (Note: The `SSH_PRIVATE_KEY` env variable should have access to the jumphost as well as deployment server for this to work. Also, this method does not work with vault.)
 `SUBMODULE_DEPLOY_KEY` | null | Read access deploy key created in the submodule repo's deploy keys. | Only required for privated submodule repo. For now only one private submodule deploy key is allowed. All public submodules in repo will be fetched by default without the need of this env variable. (To create a deploy key go to: Settings > Deploy Keys > Add deploy key)
 

--- a/main.sh
+++ b/main.sh
@@ -167,6 +167,22 @@ function setup_wordpress_files() {
 	export build_root="$(pwd)"
 
 	WP_VERSION=${WP_VERSION:-"latest"}
+
+	if [[ "$WP_MINOR_UPDATE" == "true" ]] && [[ "$WP_VERSION" != "latest" ]]; then
+		# Ref: https://codex.wordpress.org/WordPress.org_API
+		# Ref: https://wordpress.stackexchange.com/a/368758/189798
+		LATEST_MINOR_VERSION=$(\
+			curl -s "https://api.wordpress.org/core/version-check/1.7/?version=$WP_VERSION" | \
+			jq -r '[.offers[]|select(.response=="autoupdate")][-1].version'
+		)
+		if [[ "$LATEST_MINOR_VERSION" == "$WP_VERSION"* ]]; then
+			WP_VERSION="$LATEST_MINOR_VERSION"
+			echo "Using $LATEST_MINOR_VERSION as the latest minor version."
+		else
+			echo "$WP_VERSION is the latest minor version."
+		fi
+	fi
+
 	wp core download --version="$WP_VERSION" --allow-root
 
 	rm -r wp-content/

--- a/main.sh
+++ b/main.sh
@@ -169,13 +169,12 @@ function setup_wordpress_files() {
 	WP_VERSION=${WP_VERSION:-"latest"}
 
 	if [[ "$WP_MINOR_UPDATE" == "true" ]] && [[ "$WP_VERSION" != "latest" ]]; then
-		# Ref: https://codex.wordpress.org/WordPress.org_API
-		# Ref: https://wordpress.stackexchange.com/a/368758/189798
 		LATEST_MINOR_VERSION=$(\
 			curl -s "https://api.wordpress.org/core/version-check/1.7/?version=$WP_VERSION" | \
 			jq -r '[.offers[]|select(.response=="autoupdate")][-1].version'
 		)
-		if [[ "$LATEST_MINOR_VERSION" == "$WP_VERSION"* ]]; then
+		MAJOR_DOT_MINOR=$(echo "$WP_VERSION" | cut -c1-3)
+		if [[ "$LATEST_MINOR_VERSION" == "$MAJOR_DOT_MINOR"* ]]; then
 			WP_VERSION="$LATEST_MINOR_VERSION"
 			echo "Using $LATEST_MINOR_VERSION as the latest minor version."
 		else


### PR DESCRIPTION
Adds `WP_MINOR_UPDATE` env variable support for the workflow file.
If set to `true`, it will take the latest minor version of the specified `WP_VERSION`. 