### PR TITLE
Include default README.md file

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -46,7 +46,6 @@ set( 'rsync', [
 		'.gitlab-ci.yml',
 		'Gruntfile.js',
 		'package.json',
-		'README.md',
 		'gulpfile.js',
 		'.circleci',
 		'package-lock.json',


### PR DESCRIPTION
Whenever we are run `wp core verify-checksums` its failed due to following files

```
wp core verify-checksums
Warning: File doesn't exist: wp-includes/sodium_compat/src/Core32/Curve25519/README.md
Warning: File doesn't exist: wp-includes/sodium_compat/src/Core/Curve25519/README.md
Error: WordPress installation doesn't verify against checksums.
```

I think we should include default files so checksum verification pass and we only detect which site had actually issue instead of false positive like above.