### PR TITLE
feat: persist llms.txt across deployments via shared symlink

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -51,6 +51,7 @@ set( 'rsync', [
 		'package-lock.json',
 		'package.json',
 		'phpcs.xml',
+		'llms.txt',
 	],
 	'exclude-file'  => true,
 	'include'       => [],
@@ -171,6 +172,18 @@ task( 'permissions:set', function () {
 	writeln( '<info>' . $output . '</info>' );
 
 } );
+
+desc( 'Symlink llms.txt from shared if it exists' );
+task( 'link_llms_txt', function () {
+	$shared_file  = get( 'deploy_path' ) . '/shared/llms.txt';
+	$release_file = get( 'release_path' ) . '/llms.txt';
+
+	if ( test( "[ -f $shared_file ]" ) ) {
+		run( "ln -sfn $shared_file $release_file" );
+	}
+} );
+
+after( 'deploy:shared', 'link_llms_txt' );
 
 $wp_tasks = [
 	'deploy:prepare',

--- a/deploy.php
+++ b/deploy.php
@@ -174,16 +174,13 @@ task( 'permissions:set', function () {
 } );
 
 desc( 'Symlink llms.txt from shared if it exists' );
-task( 'link_llms_txt', function () {
-	$shared_file  = get( 'deploy_path' ) . '/shared/llms.txt';
-	$release_file = get( 'release_path' ) . '/llms.txt';
-
-	if ( test( "[ -f $shared_file ]" ) ) {
-		run( "ln -sfn $shared_file $release_file" );
+task( 'llms:link', function () {
+	if ( test( '[ -f "{{shared_path}}/llms.txt" ]' ) ) {
+		run( 'ln -sfn "{{shared_path}}/llms.txt" "{{release_path}}/llms.txt"' );
 	}
 } );
 
-after( 'deploy:shared', 'link_llms_txt' );
+after( 'deploy:shared', 'llms:link' );
 
 $wp_tasks = [
 	'deploy:prepare',


### PR DESCRIPTION
## Summary

- Adds `llms.txt` to the rsync exclude list so it is never deleted by `--delete`/`--delete-excluded` during deployments
- Adds a `llms:link` task that symlinks `shared/llms.txt` into each release — but **only if the file exists** on the server; sites without the file are completely unaffected
- Uses `{{shared_path}}` and `{{release_path}}` Deployer placeholders with quoted paths (handles spaces in deploy paths)
- Task follows the `namespace:action` naming convention used throughout the file
- Uses `after('deploy:shared', ...)` so it runs as part of the standard Deployer flow

## Behaviour

| Server state | Result |
|---|---|
| `shared/llms.txt` exists | Symlinked as `current/llms.txt` pointing to the absolute `shared/llms.txt` path — persists across all future deploys |
| `shared/llms.txt` absent | Task runs, finds nothing, skips — deploy passes normally |

## How to activate for a site (one-time server setup)

For sites that already have `llms.txt` in their current release, copy it to the shared directory **before** the next deploy:

```bash
SITE=your-site.domain
HTDOCS="/opt/easyengine/sites/$SITE/app/htdocs"
cp "$HTDOCS/current/llms.txt" "$HTDOCS/shared/llms.txt"
```

On the next deploy the symlink is created automatically. New sites can simply place the file in `shared/` whenever ready.

## Test plan

- [ ] Deploy to a site that has `shared/llms.txt` → confirm `current/llms.txt` is a symlink pointing to the absolute path of `shared/llms.txt`
- [ ] Deploy to a site without `shared/llms.txt` → confirm deploy passes with no errors
- [ ] Trigger a second deploy on a site with the file → confirm the file content persists unchanged