### PR TITLE
fix(deploy): use deploy_path/shared and relative symlink for llms.txt

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -175,8 +175,8 @@ task( 'permissions:set', function () {
 
 desc( 'Symlink llms.txt from shared if it exists' );
 task( 'llms:link', function () {
-	if ( test( '[ -f "{{shared_path}}/llms.txt" ]' ) ) {
-		run( 'ln -sfn "{{shared_path}}/llms.txt" "{{release_path}}/llms.txt"' );
+	if ( test( '[ -f "{{deploy_path}}/shared/llms.txt" ]' ) ) {
+		run( '{{bin/symlink}} "{{deploy_path}}/shared/llms.txt" "{{release_path}}/llms.txt"' );
 	}
 } );
 


### PR DESCRIPTION
## Summary

The `llms:link` task (added in #61, shipped in v3.4.0) fails on **every** deployment,
aborting the deploy. This fixes it with a small parameter + symlink correction.

## Problem

`deploy.php` referenced `{{shared_path}}`, which is **not a valid Deployer 6 parameter**.
Deployer throws while parsing the `test()` argument — before the file check even runs —
so the task fails regardless of whether `llms.txt` exists:

```
➤ Executing task deploy:shared   ✔ Ok
➤ Executing task llms:link
In Configuration.php line 74:
  Configuration parameter `shared_path` does not exist.
```

Because `deploy:shared` runs on both the WP and non-WP flows, this breaks all deploys
on v3.4.0 (and any consumer pointed at `@v3` while it tracked v3.4.0).

## Fix

Two corrections to the `llms:link` task:

1. **Valid path** — `{{shared_path}}` → `{{deploy_path}}/shared`, matching how
   Deployer 6 builds the shared path (`recipe/deploy/shared.php`).
2. **Relative symlink** — create the link with `{{bin/symlink}}` (`ln -nfs --relative`)
   instead of a raw absolute `ln -sfn`. This is the same helper Deployer uses for its
   `current` and shared-dir symlinks. An absolute target breaks inside containers
   (e.g. EasyEngine, where the host path `/opt/easyengine/.../shared/...` doesn't exist
   at the in-container mount `/var/www/htdocs/...`); a relative link
   (`../../shared/llms.txt`) resolves correctly in both.

```diff
-	if ( test( '[ -f "{{shared_path}}/llms.txt" ]' ) ) {
-		run( 'ln -sfn "{{shared_path}}/llms.txt" "{{release_path}}/llms.txt"' );
+	if ( test( '[ -f "{{deploy_path}}/shared/llms.txt" ]' ) ) {
+		run( '{{bin/symlink}} "{{deploy_path}}/shared/llms.txt" "{{release_path}}/llms.txt"' );
```

The task stays **conditional** (the `test -f` guard), so sites without
`shared/llms.txt` are completely unaffected — no symlink, no empty file. (Deployer's
native `shared_files` was considered but rejected: it symlinks unconditionally and would
leave a dangling `llms.txt` symlink in every release on sites that don't use the feature.)

## Testing

- Verified `shared_path` is undefined in Deployer 6 (`grep -r shared_path vendor/deployer/` → no matches).
- Confirmed `deploy:shared` builds the path as `{{deploy_path}}/shared`.
- Confirmed `{{bin/symlink}}` resolves to `ln -nfs --relative` on the `ubuntu:24.04` image (GNU coreutils supports `--relative`).

## Follow-up

`deploy.php` is baked into the Docker image, so this needs a **v3.4.1** release
(bump `action.yml`, tag, build, move `v3`) to take effect for consumers.

Refs: #61
