### PR TITLE
fix(ci): remove duplicate "What's Changed" heading in release draft

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,6 @@ jobs:
     - name: Publish a Draft Release
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
-        body: |
-          ## What's Changed
-
         draft: true  # Creates a Draft Release
         name: ${{ env.release_name }}
         generate_release_notes: true
-        append_body: true


### PR DESCRIPTION
## Summary

Release drafts created by `release.yaml` show **two** `## What's Changed` headings.

## Cause

The workflow set a hardcoded `body: "## What's Changed"` **and** enabled
`generate_release_notes: true` (GitHub's auto-generated notes also begin with
`## What's Changed`), then stacked them with `append_body: true`:

```
## What's Changed      ← hardcoded body
## What's Changed      ← generated notes
* … by @… in #…
```

## Fix

Drop the hardcoded `body` and `append_body`, and rely on `generate_release_notes: true`,
which already produces a complete `## What's Changed` section plus the Full Changelog link.

```diff
       with:
-        body: |
-          ## What's Changed
-
         draft: true  # Creates a Draft Release
         name: ${{ env.release_name }}
         generate_release_notes: true
-        append_body: true
```

Only affects releases created after this merges; existing drafts are unchanged.
